### PR TITLE
Upgrade cryptography to version 3.3.2

### DIFF
--- a/fake-vulnerabilities-python/requirements.txt
+++ b/fake-vulnerabilities-python/requirements.txt
@@ -34,5 +34,5 @@ seaborn>=0.11.0
 # Cython  # for pycocotools https://github.com/cocodataset/cocoapi/issues/172
 # pycocotools>=2.0  # COCO mAP
 # roboflow
-cryptography==2.8.0
+cryptography==3.3.2.0
 thop  # FLOPs computation


### PR DESCRIPTION
![large-logo-191x34](https://user-images.githubusercontent.com/33268211/98482806-aa4ffd00-21b8-11eb-8a44-82947e3acf9a.png)<p>Upgrades cryptography to 3.3.2 to fix vulnerabilities in current version