### PR TITLE
Upgrade spring-security-core to version 4.2.16.RELEASE

### DIFF
--- a/fake-vulnerabilities-java-maven/pom.xml
+++ b/fake-vulnerabilities-java-maven/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.example.app</groupId>
@@ -31,7 +33,7 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
-            <version>2.0.2</version>
+            <version>4.2.16.RELEASE</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
![large-logo-191x34](https://user-images.githubusercontent.com/33268211/98482806-aa4ffd00-21b8-11eb-8a44-82947e3acf9a.png)<p>Upgrades spring-security-core to 4.2.16.RELEASE to fix vulnerabilities in current version