### PR TITLE
Upgrade spring-security-core to version 5.3.4.RELEASE

### DIFF
--- a/java-maven-with-sub-projects/module-one/pom.xml
+++ b/java-maven-with-sub-projects/module-one/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
-            <version>2.0.1</version>
+            <version>5.3.4.RELEASE</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
![large-logo-191x34](https://user-images.githubusercontent.com/33268211/98482806-aa4ffd00-21b8-11eb-8a44-82947e3acf9a.png)<p>Upgrades spring-security-core to 5.3.4.RELEASE to fix vulnerabilities in current version