### PR TITLE
Upgrade Bootstrap.Less to version 3.4.1

### DIFF
--- a/dotnet/OpenXmlFormats/NPOI.OpenXmlFormats.Core.csproj
+++ b/dotnet/OpenXmlFormats/NPOI.OpenXmlFormats.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
-    <DocumentationFile></DocumentationFile>
+    <DocumentationFile/>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="Bootstrap.Less" Version="2.1.1" PrivateAssets="All" />
-    <PackageReference Include="FastReport.OpenSource" Version="2020.4.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
+    <PackageReference Include="Bootstrap.Less" PrivateAssets="All" Version="3.4.1" />
+    <PackageReference Include="FastReport.OpenSource" PrivateAssets="All" Version="2020.4.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
![large-logo-191x34](https://user-images.githubusercontent.com/33268211/98482806-aa4ffd00-21b8-11eb-8a44-82947e3acf9a.png)<p>Upgrades Bootstrap.Less to 3.4.1 to fix vulnerabilities in current version