### PR TITLE
Upgrade MessagePack.UnityShims to version 2.0.123-beta

### DIFF
--- a/dotnet/src/AngleSharp.Performance.Html/AngleSharp.Performance.Html.csproj
+++ b/dotnet/src/AngleSharp.Performance.Html/AngleSharp.Performance.Html.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <ApplicationIcon />
+    <ApplicationIcon/>
     <OutputType>Exe</OutputType>
-    <StartupObject />
+    <StartupObject/>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,5 +17,6 @@
   <ItemGroup>
     <PackageReference Include="CsQuery" Version="1.3.5-beta5" />
     <PackageReference Include="HtmlAgilityPack" Version="1.8.10" />
-  </ItemGroup>
+  <PackageReference Include="MessagePack.UnityShims" Version="2.0.123-beta" />
+</ItemGroup>
 </Project>

--- a/dotnet/src/AngleSharp.Performance.Selector/AngleSharp.Performance.Selector.csproj
+++ b/dotnet/src/AngleSharp.Performance.Selector/AngleSharp.Performance.Selector.csproj
@@ -16,8 +16,6 @@
 
   <ItemGroup>
     <PackageReference Include="CsQuery" Version="1.3.5-beta5" />
-    <PackageReference Include="MetadataExtractor" Version="2.2.0" />
-    <PackageReference Include="MessagePack.UnityShims" Version="0.6.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
![large-logo-191x34](https://user-images.githubusercontent.com/33268211/98482806-aa4ffd00-21b8-11eb-8a44-82947e3acf9a.png)<p>Upgrades MessagePack.UnityShims to 2.0.123-beta to fix vulnerabilities in current version