### PR TITLE
Upgrade MessagePack.UnityShims to version 0.6.1

### DIFF
--- a/dotnet/src/AngleSharp.Performance.Selector/AngleSharp.Performance.Selector.csproj
+++ b/dotnet/src/AngleSharp.Performance.Selector/AngleSharp.Performance.Selector.csproj
@@ -16,8 +16,6 @@
 
   <ItemGroup>
     <PackageReference Include="CsQuery" Version="1.3.5-beta5" />
-    <PackageReference Include="MetadataExtractor" Version="2.2.0" />
-    <PackageReference Include="MessagePack.UnityShims" Version="0.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/src/AngleSharp.Performance.Utilities/AngleSharp.Performance.Utilities.csproj
+++ b/dotnet/src/AngleSharp.Performance.Utilities/AngleSharp.Performance.Utilities.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="MetadataExtractor" Version="2.2.0" />
-    <PackageReference Include="MessagePack.UnityShims" Version="0.6.0" />
+    <PackageReference Include="MessagePack.UnityShims" Version="0.6.1" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
![large-logo-191x34](https://user-images.githubusercontent.com/33268211/98482806-aa4ffd00-21b8-11eb-8a44-82947e3acf9a.png)<p>Upgrades MessagePack.UnityShims to 0.6.1 to fix vulnerabilities in current version