### PR TITLE
Upgrade MessagePack.UnityShims to version 2.0.123-beta

### DIFF
--- a/dotnet/src/AngleSharp/AngleSharp.Core.csproj
+++ b/dotnet/src/AngleSharp/AngleSharp.Core.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.0" />
-    <PackageReference Include="MessagePack.UnityShims" Version="0.6.0" />
+    <PackageReference Include="MessagePack.UnityShims" Version="2.0.123-beta" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">


### PR DESCRIPTION
![large-logo-191x34](https://user-images.githubusercontent.com/33268211/98482806-aa4ffd00-21b8-11eb-8a44-82947e3acf9a.png)<p>Upgrades MessagePack.UnityShims to 2.0.123-beta to fix vulnerabilities in current version