### PR TITLE
Upgrade qs to version 6.10.1

### DIFF
--- a/npm/socket.io-master/examples/cluster-nginx/server/package.json
+++ b/npm/socket.io-master/examples/cluster-nginx/server/package.json
@@ -7,6 +7,7 @@
   "private": true,
   "license": "MIT",
   "dependencies": {
+    "qs": "6.10.1",
     "@socket.io/redis-adapter": "^7.0.1",
     "express": "4.13.4",
     "redis": "^3.1.2",


### PR DESCRIPTION
![large-logo-191x34](https://user-images.githubusercontent.com/33268211/98482806-aa4ffd00-21b8-11eb-8a44-82947e3acf9a.png)<p>Upgrades qs to 6.10.1 to fix vulnerabilities in current version