### PR TITLE
Upgrade bcprov-jdk15on to version 1.70

### DIFF
--- a/java-maven-with-sub-projects/pom.xml
+++ b/java-maven-with-sub-projects/pom.xml
@@ -1,33 +1,64 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+        
     <modelVersion>4.0.0</modelVersion>
+        
     <groupId>com.example.app</groupId>
+        
     <artifactId>java-maven-with-sub-projects</artifactId>
+        
     <packaging>pom</packaging>
+        
     <version>1.0-SNAPSHOT</version>
+        
     <modules>
+                
         <module>module-one</module>
+                
         <module>module-two</module>
+                
         <module>module-three</module>
+            
     </modules>
+        
     <name>my-vulnerable-app</name>
+        
     <url>http://maven.apache.org</url>
+        
     <dependencies>
+                
         <dependency>
+                        
             <groupId>junit</groupId>
+                        
             <artifactId>junit</artifactId>
+                        
             <version>3.8.1</version>
+                        
             <scope>test</scope>
+                    
         </dependency>
+                
         <dependency>
+                        
             <groupId>commons-collections</groupId>
+                        
             <artifactId>commons-collections</artifactId>
+                        
             <version>3.2</version>
+                    
         </dependency>
+                
         <dependency>
+                        
             <groupId>org.bouncycastle</groupId>
+                        
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.55</version>
+                        
+            <version>1.70</version>
+                    
         </dependency>
+            
     </dependencies>
+    
 </project>


### PR DESCRIPTION
![large-logo-191x34](https://user-images.githubusercontent.com/33268211/98482806-aa4ffd00-21b8-11eb-8a44-82947e3acf9a.png)<p>Upgrades bcprov-jdk15on to 1.70 to fix vulnerabilities in current version